### PR TITLE
Remove header section to revert to old version

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -11,11 +11,6 @@
 </head>
 <body>
     <div class="container">
-        <header>
-            <h1>Course Materials Assistant</h1>
-            <p class="subtitle">Ask questions about courses, instructors, and content</p>
-        </header>
-
         <!-- Theme Toggle Button -->
         <button id="themeToggle" class="theme-toggle" aria-label="Toggle theme">
             <svg class="sun-icon" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -124,27 +124,6 @@ body {
     transform: rotate(-90deg) scale(0);
 }
 
-/* Header - Hidden */
-header {
-    display: none;
-}
-
-header h1 {
-    font-size: 1.75rem;
-    font-weight: 700;
-    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-    -webkit-background-clip: text;
-    -webkit-text-fill-color: transparent;
-    background-clip: text;
-    margin: 0;
-}
-
-.subtitle {
-    font-size: 0.95rem;
-    color: var(--text-secondary);
-    margin-top: 0.5rem;
-}
-
 /* Main Content Area with Sidebar */
 .main-content {
     flex: 1;
@@ -862,15 +841,7 @@ details[open] .suggested-header::before {
     .chat-main {
         order: 1;
     }
-    
-    header {
-        padding: 1rem;
-    }
-    
-    header h1 {
-        font-size: 1.5rem;
-    }
-    
+
     .chat-messages {
         padding: 1rem;
     }


### PR DESCRIPTION
Fixes #2

Removed the header section from the application to revert to the old version while keeping the theme toggle functionality.

### Changes
- Removed 'Course Materials Assistant' h1 header
- Removed subtitle about asking questions
- Kept theme toggle button functionality intact

Generated with [Claude Code](https://claude.ai/code)